### PR TITLE
bug: fix "aud" to not be remote host url

### DIFF
--- a/js/vapid.js
+++ b/js/vapid.js
@@ -20,8 +20,8 @@ class VapidToken {
          *
          * VAPID allows for self identification of a subscription update.
          *
-         * :param aud: Audience - email of the admin contact for this update.
-         * :param sub: Subscription - Optional site URL for this update.
+         * :param sub: Subscription - email of the admin contact for this
+         *      update.
          * :param exp: Expiration - UTC expiration of this update. Defaults
          *      to now + 24 hours
          */
@@ -157,8 +157,8 @@ class VapidToken {
         if (! claims.hasOwnProperty("exp")) {
             claims.exp = parseInt(Date.now()*.001) + 86400;
         }
-        if (! claims.hasOwnProperty("aud")) {
-            throw new Error(this.lang.errs.ERR_CLAIM_MIS, "aud");
+        if (! claims.hasOwnProperty("sub")) {
+            throw new Error(this.lang.errs.ERR_CLAIM_MIS, "sub");
         }
         let alg = {name:"ECDSA", namedCurve: "P-256", hash:{name:"SHA-256"}};
         let headStr = this.mzcc.toUrlBase64(

--- a/python/py_vapid/__init__.py
+++ b/python/py_vapid/__init__.py
@@ -106,10 +106,6 @@ class Vapid(object):
         """
         if not claims.get('exp'):
             claims['exp'] = int(time.time()) + 86400
-        if not claims.get('aud'):
-            raise VapidException(
-                "Missing 'aud' from claims. "
-                "'aud' is your site's URL.")
         if not claims.get('sub'):
             raise VapidException(
                 "Missing 'sub' from claims. "

--- a/python/py_vapid/tests/test_vapid.py
+++ b/python/py_vapid/tests/test_vapid.py
@@ -115,8 +115,5 @@ class VapidTestCase(unittest.TestCase):
         v = Vapid("/tmp/private")
         self.assertRaises(VapidException,
                           v.sign,
-                          {'sub': "a@e.c"})
-        self.assertRaises(VapidException,
-                          v.sign,
-                          {'aud': "https://e.c"})
+                          {'aud': "p.example.com"})
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 
 def read_from(file):


### PR DESCRIPTION
"aud" is now a completely optional field. Strict checks only for "sub".

closes #15
